### PR TITLE
Augmentable operators optimization: * is commutative when an operand is scalar

### DIFF
--- a/src/ast.fs
+++ b/src/ast.fs
@@ -91,6 +91,10 @@ and Type = {
         not (Set.intersect (set this.typeQ) (set ["out"; "inout"])).IsEmpty
     member this.IsExternal =
         List.exists (fun s -> Set.contains s Builtin.externalQualifiers) this.typeQ
+    member this.isScalar =
+        match this.name with
+            | TypeName n -> Builtin.builtinScalarTypes.Contains n
+            | _ -> false
     override t.ToString() =
         let name = match t.name with
                    | TypeName n -> n

--- a/src/builtin.fs
+++ b/src/builtin.fs
@@ -10,18 +10,24 @@ let keywords = System.Collections.Generic.HashSet<_>([
   "const"; "uniform"; "buffer"; "shared"; "attribute"; "varying"
 ])
 
-let builtinTypes = set([
-    yield! [ "void"; "bool"; "int"; "uint"; "float"; "double" ]
+let builtinScalarTypes = set [
+    "bool"; "int"; "uint"; "float"; "double"
+]
+let builtinVectorTypes = set([
     for p in [""; "d"; "b"; "i"; "u"] do
         for n in ["2"; "3"; "4"] do
             yield p+"vec"+n
+])
+let builtinMatrixTypes = set([
     for p in [""; "d"] do
         for n in ["2"; "3"; "4"] do
             yield p+"mat"+n
         for c in ["2"; "3"; "4"] do
             for r in ["2"; "3"; "4"] do
                 yield p+"mat"+c+"x"+r
-    ])
+])
+
+let builtinTypes = set [ "void" ] + builtinScalarTypes + builtinVectorTypes + builtinMatrixTypes;
 
 let implicitConversions = // (from, to)
     [


### PR DESCRIPTION
I hoped to make it handle all cases (`*` is commutative when at least one operand is scalar or both are vector) but that would require determining the type of an expression.

For now, when an operand is a variable declared as a scalar type the optimization is possible for `*`.