### PR TITLE
Misc improvements

### DIFF
--- a/src/ast.fs
+++ b/src/ast.fs
@@ -199,6 +199,9 @@ type Shader = {
 [<NoComparison>] [<RequireQualifiedAccess>]
 type BlockLevel = FunctionRoot of FunctionType | Nested | Unknown
 
+[<RequireQualifiedAccess>]
+type Level = TopLevel | InFunc
+
 [<NoComparison; NoEquality>]
 type MapEnv = {
     fExpr: MapEnv -> Expr -> Expr

--- a/tests/unit/arg-inlining.expected
+++ b/tests/unit/arg-inlining.expected
@@ -60,14 +60,23 @@ float noinline_cannotInlineWhenArgIsNotInlinable(float a)
 }
 float f()
 {
-  float s=noinline_canInlineWhenResolvable();
-  s+=noinline_cannotInlineWhenNotResolvable(1.);
-  s+=noinline_canInlineWhenInParameter();
-  s+=noinline_cannotInlineWhenOutParameter(s);
-  s+=noinline_cannotInlineWhenInOutParameter(s);
-  s=s+noinline_canInlineWhenArgIsAlwaysTheSame()+noinline_cannotInlineWhenArgsAreDifferent(1.)+noinline_cannotInlineWhenArgsAreDifferent(2.)+noinline_canInlineWhenArgIsInlinable1()+noinline_canInlineWhenArgIsInlinable2()+noinline_canInlineWhenArgIsInlinable3()+noinline_canInlineWhenArgIsInlinable4()+noinline_canInlineWhenArgIsInlinable5()+noinline_canInlineWhenArgIsInlinable6();
-  s+=noinline_cannotInlineWhenArgIsNotInlinable(s);
-  return s+noinline_cannotInlineWhenArgIsNotInlinable(acos(s));
+  float s=0.;
+  s+=s+noinline_canInlineWhenResolvable();
+  s+=s+noinline_cannotInlineWhenNotResolvable(1.);
+  s+=s+noinline_canInlineWhenInParameter();
+  s+=s+noinline_cannotInlineWhenOutParameter(s);
+  s+=s+noinline_cannotInlineWhenInOutParameter(s);
+  s+=s+noinline_canInlineWhenArgIsAlwaysTheSame();
+  s+=s+noinline_cannotInlineWhenArgsAreDifferent(1.);
+  s+=s+noinline_cannotInlineWhenArgsAreDifferent(2.);
+  s+=s+noinline_canInlineWhenArgIsInlinable1();
+  s+=s+noinline_canInlineWhenArgIsInlinable2();
+  s+=s+noinline_canInlineWhenArgIsInlinable3();
+  s+=s+noinline_canInlineWhenArgIsInlinable4();
+  s+=s+noinline_canInlineWhenArgIsInlinable5();
+  s+=s+noinline_canInlineWhenArgIsInlinable6();
+  s+=s+noinline_cannotInlineWhenArgIsNotInlinable(s);
+  return s+noinline_cannotInlineWhenArgIsNotInlinable(acos(s))+s;
 }
 void main()
 {

--- a/tests/unit/arg-inlining.frag
+++ b/tests/unit/arg-inlining.frag
@@ -23,25 +23,25 @@ float f()
 {
 	float s = 0.;
 	
-	s += noinline_canInlineWhenResolvable(1.);
-	s += noinline_cannotInlineWhenNotResolvable(1.);
+	s += s + noinline_canInlineWhenResolvable(1.);
+	s += s + noinline_cannotInlineWhenNotResolvable(1.);
 	
-	s += noinline_canInlineWhenInParameter(1.);
-	s += noinline_cannotInlineWhenOutParameter(s);
-	s += noinline_cannotInlineWhenInOutParameter(s);
+	s += s + noinline_canInlineWhenInParameter(1.);
+	s += s + noinline_cannotInlineWhenOutParameter(s);
+	s += s + noinline_cannotInlineWhenInOutParameter(s);
 	
-	s += noinline_canInlineWhenArgIsAlwaysTheSame(1.);
-	s += noinline_cannotInlineWhenArgsAreDifferent(1.);
-	s += noinline_cannotInlineWhenArgsAreDifferent(2.);
+	s += s + noinline_canInlineWhenArgIsAlwaysTheSame(1.);
+	s += s + noinline_cannotInlineWhenArgsAreDifferent(1.);
+	s += s + noinline_cannotInlineWhenArgsAreDifferent(2.);
 
-	s += noinline_canInlineWhenArgIsInlinable1(true);
-	s += noinline_canInlineWhenArgIsInlinable2(-18);
-	s += noinline_canInlineWhenArgIsInlinable3(456.0);
-	s += noinline_canInlineWhenArgIsInlinable4(vec3(9));
-	s += noinline_canInlineWhenArgIsInlinable5(acos(-1.));
-	s += noinline_canInlineWhenArgIsInlinable6(1./3.);
-	s += noinline_cannotInlineWhenArgIsNotInlinable(s);
-	s += noinline_cannotInlineWhenArgIsNotInlinable(acos(s));
+	s += s + noinline_canInlineWhenArgIsInlinable1(true);
+	s += s + noinline_canInlineWhenArgIsInlinable2(-18);
+	s += s + noinline_canInlineWhenArgIsInlinable3(456.0);
+	s += s + noinline_canInlineWhenArgIsInlinable4(vec3(9));
+	s += s + noinline_canInlineWhenArgIsInlinable5(acos(-1.));
+	s += s + noinline_canInlineWhenArgIsInlinable6(1./3.);
+	s += s + noinline_cannotInlineWhenArgIsNotInlinable(s);
+	s += s + noinline_cannotInlineWhenArgIsNotInlinable(acos(s));
 	
 	return s;
 }

--- a/tests/unit/operators.expected
+++ b/tests/unit/operators.expected
@@ -31,6 +31,14 @@
  "{"
    "x=(x+=1.,length(vec3(x)));"
    "return x*x*sin((x*=x,x));"
+ "}"
+ "float desugar_compound_assignment_for_ternary(float x)"
+ "{"
+   "x+=x*x;"
+   "x=x==sqrt(x)?"
+     "x+cos(x):"
+     "x*sin(x);"
+   "return x*x;"
  "}",
 
 #endif

--- a/tests/unit/operators.frag
+++ b/tests/unit/operators.frag
@@ -40,3 +40,13 @@ float f(float x)
 	float a = (x += 1.0, length(vec3(x)));
 	return a*a*sin((a*=a, a));
 }
+
+float desugar_compound_assignment_for_ternary(float x)
+{
+	x += x * x;
+	if (x == sqrt(x))
+		x += cos(x);
+	else
+		x *= sin(x);
+	return x * x;
+}


### PR DESCRIPTION
* Use an active pattern to desugar compound assignments.
* Change bool isTopLevel into an enum for readability
* Change the arg-inlining test to go back to a more readable state
* Reuse varUsesInStmt more