### PR TITLE
Structs: allow field names that look like vec4 fields in some cases

### DIFF
--- a/src/parse.fs
+++ b/src/parse.fs
@@ -159,15 +159,7 @@ type private ParseImpl() =
 
     // A type block, like struct or interface blocks
     let blockSpecifier prefix =
-
-        // Restriction on field names
-        let check ((_,l) as arg : Ast.Decl) =
-            for decl in l do
-                if decl.name.Name <> Rewriter.renameField decl.name.Name then
-                    failwithf "Record field name '%s' is not allowed by Shader Minifier,\nbecause it looks like a vec4 field name." decl.name.Name
-            arg
-
-        let decls = many (declaration .>> ch ';' |>> check)
+        let decls = many (declaration .>> ch ';')
         let name = opt ident
         pipe2 name (between (ch '{') (ch '}') decls)
             (fun n d ->

--- a/src/rewriter.fs
+++ b/src/rewriter.fs
@@ -6,11 +6,6 @@ open Builtin
 open Ast
 open Options.Globals
 
-let renameField field =
-    if isFieldSwizzle field then
-        field |> String.map (fun c -> options.canonicalFieldNames.[swizzleIndex c])
-    else field
-
 let private commaSeparatedExprs = List.reduce (fun a b -> FunCall(Op ",", [a; b]))
 
 let rec private sideEffects = function

--- a/tests/commands.txt
+++ b/tests/commands.txt
@@ -33,6 +33,7 @@
 --no-remove-unused --format indented -o tests/unit/interface_block.frag.expected tests/unit/interface_block.frag
 --no-remove-unused --no-renaming --format indented -o tests/unit/ternary.frag.expected tests/unit/ternary.frag
 --no-remove-unused --no-renaming --format indented -o tests/unit/reuse-var.frag.expected tests/unit/reuse-var.frag
+--no-remove-unused --format indented -o tests/unit/struct.frag.expected tests/unit/struct.frag
 
 # Unused removal tests
 

--- a/tests/unit/struct.frag
+++ b/tests/unit/struct.frag
@@ -1,0 +1,14 @@
+struct Foo {
+  int field1;
+  int field2;
+  int ab;
+  int st;
+};
+
+void main() {
+  Foo f;
+  f.field1 = 1;
+  f.field2 = 2;
+  f.ab = 3;
+  f.st = 4;
+}

--- a/tests/unit/struct.frag.expected
+++ b/tests/unit/struct.frag.expected
@@ -1,0 +1,9 @@
+struct Foo{int field1;int field2;int wz;int xy;};
+void main()
+{
+  Foo i;
+  i.field1=1;
+  i.field2=2;
+  i.wz=3;
+  i.xy=4;
+}


### PR DESCRIPTION
e.g. we can rename `ab` to `wz` in `struct Foo{int ab;}`