### PR TITLE
Treat as external the global fields of an interface block

### DIFF
--- a/src/ast.fs
+++ b/src/ast.fs
@@ -79,8 +79,10 @@ and Expr =
 
 and TypeSpec =
     | TypeName of string
-    // e.g. struct foo { float x; float y; }
+    // struct or interface block, e.g. struct foo { float x; float y; }
     | TypeBlock of string(*type*) * Ident option(*name*) * Decl list
+    // An interface block followed by an instance name (in a TLDecl), like structs, declares an instance.
+    // An interface block without an instance name (in a TypeDecl), unlike structs, introduces a set of external global variables.
 
 and Type = {
     name: TypeSpec // e.g. int
@@ -167,7 +169,7 @@ and TopLevel =
     | TLDirective of string list
     | Function of FunctionType * Stmt
     | TLDecl of Decl
-    | TypeDecl of TypeSpec // structs
+    | TypeDecl of TypeSpec // structs or interface blocks
     | Precision of Type
 
 let makeType name tyQ sizes = {Type.name=name; typeQ=tyQ; arraySizes=sizes}

--- a/tests/commands.txt
+++ b/tests/commands.txt
@@ -63,6 +63,7 @@
 # Multifile tests
 
 --no-remove-unused --move-declarations --format c-array -o tests/unit/inout.expected tests/unit/inout.frag tests/unit/inout2.frag
+--no-remove-unused --format c-array -o tests/unit/interface-block-renaming.expected tests/unit/interface-block-renaming1.frag tests/unit/interface-block-renaming2.frag
 
 # kkp symbols tests
 

--- a/tests/unit/interface-block-renaming.expected
+++ b/tests/unit/interface-block-renaming.expected
@@ -1,0 +1,18 @@
+// Generated with  (https://github.com/laurentlb/Shader_Minifier/)
+#ifndef SHADER_MINIFIER_IMPL
+#ifndef SHADER_MINIFIER_HEADER
+# define SHADER_MINIFIER_HEADER
+# define VAR_field "U"
+#endif
+
+#else // if SHADER_MINIFIER_IMPL
+
+// tests/unit/interface-block-renaming1.frag
+ "#version 460\n"
+ "uniform Uniform1{vec4 U;};",
+
+// tests/unit/interface-block-renaming2.frag
+ "#version 460\n"
+ "uniform Uniform1{vec4 U;};",
+
+#endif

--- a/tests/unit/interface-block-renaming1.frag
+++ b/tests/unit/interface-block-renaming1.frag
@@ -1,0 +1,4 @@
+#version 460
+// https://github.com/laurentlb/shader-minifier/issues/430
+uniform Uniform1 { vec4 field; };
+//uniform Uniform2 { vec4 field; } instance; // TODO

--- a/tests/unit/interface-block-renaming2.frag
+++ b/tests/unit/interface-block-renaming2.frag
@@ -1,0 +1,4 @@
+#version 460
+// https://github.com/laurentlb/shader-minifier/issues/430
+uniform Uniform1 { vec4 field; };
+//uniform Uniform2 { vec4 field; } instance; // TODO


### PR DESCRIPTION
Interface blocks without an instance name introduce external global variables.