### PR TITLE
Refactor the AST visitor

### DIFF
--- a/src/parse.fs
+++ b/src/parse.fs
@@ -331,9 +331,9 @@ type private ParseImpl(options: Options.Options) =
     let jump =
         let key =
             choice [keyword "break"; keyword "continue"; keyword "discard"]
-              |>> (fun k -> Ast.Jump(Ast.stringToJumpKeyword k, None))
+              |>> (fun k -> Ast.Jump(Ast.JumpKeyword.fromString k, None))
 
-        let ret = pipe2 (keyword "return") (opt expr) (fun k e -> Ast.Jump(Ast.stringToJumpKeyword k, e))
+        let ret = pipe2 (keyword "return") (opt expr) (fun k e -> Ast.Jump(Ast.JumpKeyword.fromString k, e))
         (key <|> ret) .>> ch ';'
 
     // A statement

--- a/src/printer.fs
+++ b/src/printer.fs
@@ -257,8 +257,8 @@ type PrinterImpl(withLocations) =
             out "while(%s)%s" (exprToS indent cond) (stmtToSInd indent body)
         | DoWhile(cond, body) ->
             out "do%s%s%swhile(%s);" (nl (indent+1)) (stmtToS' (indent + 1) body |> sp) (nl indent) (exprToS indent cond)
-        | Jump(k, None) -> out "%s;" (jumpKeywordToString k)
-        | Jump(k, Some exp) -> out "%s%s;" (jumpKeywordToString k) (exprToS indent exp |> sp)
+        | Jump(k, None) -> out "%s;" k.toString
+        | Jump(k, Some exp) -> out "%s%s;" k.toString (exprToS indent exp |> sp)
         | Verbatim s ->
             // add a space at end when it seems to be needed
             if s.Length > 0 && isIdentChar s.[s.Length - 1] then s + " " else s

--- a/src/renamer.fs
+++ b/src/renamer.fs
@@ -232,7 +232,7 @@ type private RenamerImpl(options: Options.Options) =
                 | Some name -> v.Rename(name); Var v
                 | None -> Var v
             | e -> e
-        mapExpr (mapEnvExpr options mapper) expr |> ignore<Expr>
+        options.visitor(mapper).iterExpr expr
 
     let renDecl level isFieldOfAnInterfaceBlockWithoutInstanceName env (ty:Type, vars) =
         let aux (env: Env) (decl: Ast.DeclElt) =


### PR DESCRIPTION
* Move the visitor implementation into MapEnv.
* Use optional method parameters for fExpr and fStmt.
* Unrelated: move JumpKeyword helper methods into JumpKeyword.