### PR TITLE
Support For Multi-Dimensional Arrays

### DIFF
--- a/Minifier/ast.fs
+++ b/Minifier/ast.fs
@@ -291,6 +291,7 @@ type MapEnv private = {
             // e.g. in `float x = x + 1`, the two `x` are not the same!
             let ret = {
                 decl with
+                    sizes=List.map env.mapExpr decl.sizes
                     init=Option.map env.mapExpr decl.init}
             let env = {env with vars = env.vars.Add(decl.name.Name, (ty, decl))}
             env, ret

--- a/Minifier/ast.fs
+++ b/Minifier/ast.fs
@@ -150,14 +150,14 @@ and Type = {
 
 and DeclElt = {
     name: Ident // e.g. foo
-    size: Expr option // e.g. [3]
+    sizes: Expr list // e.g. [3]
     semantics: Expr list // e.g. : color
     init: Expr option // e.g. = f(x)
 } with override t.ToString() =
-        let size = if t.size = None then "" else $"[{t.size}]"
+        let sizes = if t.sizes.IsEmpty then "" else t.sizes |> List.map (fun size -> $"[{size}]") |> String.concat ""
         let init = if t.init = None then "" else $" = {t.init}"
         let sem = if t.semantics.IsEmpty then "" else $": {t.semantics}" in
-        $"{t.name}{size}{init}{sem}"
+        $"{t.name}{sizes}{init}{sem}"
 
 and Decl = Type * DeclElt list
 
@@ -216,7 +216,7 @@ and TopLevel =
     | Precision of Type
 
 let makeType name tyQ sizes = {Type.name=name; typeQ=tyQ; arraySizes=sizes}
-let makeDecl name size sem init = {name=name; size=size; semantics=sem; init=init}
+let makeDecl name sizes sem init = {name=name; sizes=sizes; semantics=sem; init=init}
 let makeFunctionType ty name args sem =
     {retType=ty; fName=name; args=args; semantics=sem}
 
@@ -291,7 +291,6 @@ type MapEnv private = {
             // e.g. in `float x = x + 1`, the two `x` are not the same!
             let ret = {
                 decl with
-                    size=Option.map env.mapExpr decl.size
                     init=Option.map env.mapExpr decl.init}
             let env = {env with vars = env.vars.Add(decl.name.Name, (ty, decl))}
             env, ret

--- a/Minifier/parse.fs
+++ b/Minifier/parse.fs
@@ -242,17 +242,17 @@ type private ParseImpl(options: Options.Options) =
 
     // eg. "int foo[] = exp, bar = 3"
     do declRef.Value <- (
-        let bracket = between (ch '[') (ch ']') (opt expr) |>> (fun size -> defaultArg size (Ast.Int (0, "")))
+        let brackets = many (between (ch '[') (ch ']') (opt expr) |>> (fun size -> defaultArg size (Ast.Int (0, ""))))
         let init = ch '=' >>. exprNoComma
-        let var = pipe4 ident (opt bracket) semantics (opt init) Ast.makeDecl
+        let var = pipe4 ident brackets semantics (opt init) Ast.makeDecl
         let list = sepBy1 var (ch ',')
         tuple2 specifiedType list
     )
 
     // e.g. int foo[]   used for function arguments
     let singleDeclaration =
-        let bracket = between (ch '[') (ch ']') (opt expr) |>> (fun size -> defaultArg size (Ast.Int (0, "")))
-        pipe4 specifiedType ident (opt bracket) semantics
+        let brackets = many (between (ch '[') (ch ']') (opt expr) |>> (fun size -> defaultArg size (Ast.Int (0, ""))))
+        pipe4 specifiedType ident brackets semantics
             (fun ty id brack sem -> (ty, [Ast.makeDecl id brack sem None]))
 
     // GLSL, eg. "uniform Transform { ... };"

--- a/Minifier/renamer.fs
+++ b/Minifier/renamer.fs
@@ -124,7 +124,7 @@ type private RenamerVisitor(options: Options.Options) =
         let renDeclElt (env: Env) (decl: DeclElt) =
             // Rename expressions in init and size
             Option.iter (renExpr env) decl.init
-            Option.iter (renExpr env) decl.size
+            List.iter (renExpr env) decl.sizes
 
             // Rename variable type
             let env: Env =

--- a/Minifier/rewriter.fs
+++ b/Minifier/rewriter.fs
@@ -426,8 +426,6 @@ type private RewriterImpl(options: Options.Options, optimizationPass: Optimizati
     // Group declarations within a block. For example, all the float variables will
     // be declared at the same time, the first time a float variable is initialized.
     // Const variables are ignored, because they must be initialized immediately.
-    // Also don't merge declarations for array types, since this only works
-    // for array types of the same size(s).
     let groupDeclarations stmts =
         let declarations = Dictionary<Type, DeclElt list>()
         let mutable skippedDeclarations = []

--- a/Minifier/rewriter.fs
+++ b/Minifier/rewriter.fs
@@ -669,7 +669,7 @@ type private RewriterImpl(options: Options.Options, optimizationPass: Optimizati
                     | _ -> []
 
                 let compatibleDeclElt = (localDecls @ args) |> List.tryFind (fun declElt1 ->
-                    declElt1.size = declElt2.size &&
+                    declElt1.sizes = declElt2.sizes &&
                     declElt1.semantics = declElt2.semantics &&
                     // The first variable must not be used after the second is declared.
                     Analyzer(options).identUsesInStmt IdentKind.Var (Block (declAfter2 @ following2)) |> List.forall (fun i -> i.Name <> declElt1.name.Name)

--- a/tests/commands.txt
+++ b/tests/commands.txt
@@ -45,6 +45,7 @@
 --no-remove-unused --no-renaming --format indented -o tests/unit/layout.frag.expected tests/unit/layout.frag
 --no-remove-unused --format indented -o tests/unit/struct.frag.expected tests/unit/struct.frag
 --no-remove-unused --format indented -o tests/unit/struct2.frag.expected tests/unit/struct2.frag
+--no-remove-unused --hlsl --no-renaming --format indented -o tests/unit/multidimensional-array.hlsl.expected tests/unit/multidimensional-array.hlsl
 
 # Unused removal tests
 

--- a/tests/unit/array.frag.expected
+++ b/tests/unit/array.frag.expected
@@ -4,7 +4,10 @@
 
 const char *array_frag =
  "#version 430\n"
- "float a[5]=float[5](3.4,4.2,5.,5.2,1.1),b[5]=float[5](3.4,4.2,5.,5.2,1.1),c[]=float[](3.4,4.2,5.,5.2,1.1),d[5]=float[](3.4,4.2,5.,5.2,1.1),e[]=float[5](3.4,4.2,5.,5.2,1.1);"
+ "float a[5]=float[5](3.4,4.2,5.,5.2,1.1),b[5]=float[5](3.4,4.2,5.,5.2,1.1);"
+ "float c[]=float[](3.4,4.2,5.,5.2,1.1);"
+ "float d[5]=float[](3.4,4.2,5.,5.2,1.1);"
+ "float e[]=float[5](3.4,4.2,5.,5.2,1.1);"
  "void arrayTypes()"
  "{}"
  "float[2] func_bank(float[2] res)"

--- a/tests/unit/multidimensional-array.hlsl
+++ b/tests/unit/multidimensional-array.hlsl
@@ -1,3 +1,13 @@
-float x[4][5];
-float y[SIZE_X][SIZE_Y];
-UserT z[SIZE_X][3];
+// All different sizes will not be merged
+float a[4][5];
+float b[SIZE_X][SIZE_Y];
+UserT c[SIZE_X][3];
+
+// Neighboring declarations with the same size will be merged
+float d[4][3];
+float e[4][3];
+
+// Non-neighboring mergable declarations are not merged
+float f[5][2];
+float g[9][15];
+float h[5][2];

--- a/tests/unit/multidimensional-array.hlsl
+++ b/tests/unit/multidimensional-array.hlsl
@@ -1,0 +1,3 @@
+float x[4][5];
+float y[SIZE_X][SIZE_Y];
+UserT z[SIZE_X][3];

--- a/tests/unit/multidimensional-array.hlsl.expected
+++ b/tests/unit/multidimensional-array.hlsl.expected
@@ -1,0 +1,3 @@
+float x[4][5];
+float y[SIZE_X][SIZE_Y];
+UserT z[SIZE_X][3];

--- a/tests/unit/multidimensional-array.hlsl.expected
+++ b/tests/unit/multidimensional-array.hlsl.expected
@@ -1,3 +1,7 @@
-float x[4][5];
-float y[SIZE_X][SIZE_Y];
-UserT z[SIZE_X][3];
+float a[4][5];
+float b[SIZE_X][SIZE_Y];
+UserT c[SIZE_X][3];
+float d[4][3],e[4][3];
+float f[5][2];
+float g[9][15];
+float h[5][2];

--- a/tests/unit/simplify.expected
+++ b/tests/unit/simplify.expected
@@ -3,9 +3,11 @@
 int i;
 float bar(float x)
 {
-  float a=6.+x,b=34.+x,arr[2]=float[2](5.,float(float[2](7.,8.).length()));
-  x=(a*=10,a*=20,a*=30,b++,arr[1]+arr[i++]);
-  return a+b+x;
+  float a=6.+x;
+  x+=34.;
+  float arr[2]=float[2](5.,float(float[2](7.,8.).length()));
+  float m=(a*=10,a*=20,a*=30,x++,arr[1]+arr[i++]);
+  return a+x+m;
 }
 float baz(float a)
 {


### PR DESCRIPTION
Adds support for multi-dimensional arrays of the form:

```
float x[3][4][8];
```

## Approach

Takes the simple approach of replacing the optional `size` attribute of the declaration AST with a (potentially empty) `sizes` list.

## Outstanding Issues

### Definition condensing

The `array.frag` unit test contains a case similar to the following (simplified for example's sake)

```
float a[5];
float b[5];
```

And expects these to be condensed to a shared one line definition

```
float a[5], b[5];
```

Notice, however, that both arrays have the same size. Turns out that, if you change the size of b to 4, for instance, the definitions still get condensed.

```
float a[5], b[4];
```

**But this is not valid HLSL (or GLSL, I think?).**

To fix this, I made it so that array definitions of different sizes can't be compactified. But, this breaks the `array.frag` test, since it has a few other cases involving arrays with unspecified sizes (i.e. `c[]`) and arrays with sizes that are evaluated as part of the minification process (`int size = 2+2; c[size];`).

Looking for feedback here; assuming keeping array definition-sharing in some capacity is the desired behavior.

### Non-neighboring, Mergeable Definitions

Currently only neighboring definitions are merged. I.e.

```
float a[3];
float b[2];
float c[3];
```

Produces

```
float a[3];
float b[2];
float c[3];
```

I.e. it does not merge a and c into a shared declaration. This seems to be a function of the way the AST transform is written.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210515599774891